### PR TITLE
include: store ABIVersion in Packages index

### DIFF
--- a/include/package-ipkg.mk
+++ b/include/package-ipkg.mk
@@ -184,6 +184,7 @@ $$(call addfield,Depends,$$(Package/$(1)/DEPENDS)
 )$$(call addfield,Section,$(SECTION)
 )$$(call addfield,Require-User,$(USERID)
 )$$(call addfield,SourceDateEpoch,$(PKG_SOURCE_DATE_EPOCH)
+)$$(if $$(ABIV_$(1)),ABIVersion: $$(ABIV_$(1))
 )$(if $(PKG_CPE_ID),CPE-ID: $(PKG_CPE_ID)
 )$(if $(filter hold,$(PKG_FLAGS)),Status: unknown hold not-installed
 )$(if $(filter essential,$(PKG_FLAGS)),Essential: yes


### PR DESCRIPTION
With the existence of ABI versions there is no clean way to determine
the package name without an attached ABI version. The Packages index is
stored on device to know what packages are installed.

The ABIVersion was recently removed in c921650382 "build: drop ABI
version from metadata", while ABI versions still exists. This becomes a
problem if a user tries to export installed packages via `ubus call
rpcd-sys packagelist` which would return package names including the ABI
version. Trying to find these packages in a later release with changes
ABI version is impossible.

This commits adds the `ABIVersion` field again. Knowing both the
combined (SourceName + ABIVersion) and the `ABIVersion` it is possible
to calculate the package `SourceName` without storing it in the
on-device package list.

Signed-off-by: Paul Spooren <mail@aparcar.org>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
